### PR TITLE
Add api/track.js, api/check-fingerprint.js, and HeatCheck tracking

### DIFF
--- a/api/check-fingerprint.js
+++ b/api/check-fingerprint.js
@@ -1,0 +1,82 @@
+// Simple KV store using Vercel's built-in Edge Config or a flat approach.
+// We use Vercel Blob (free tier) to persist fingerprint usage server-side.
+// Falls back gracefully if not configured — just trusts the client.
+
+const BLOB_TOKEN = process.env.BLOB_READ_WRITE_TOKEN
+
+async function getRecord(fingerprint) {
+  if (!BLOB_TOKEN) return null
+  try {
+    const { list } = await import('@vercel/blob')
+    const { blobs } = await list({ prefix: `hc-fp/${fingerprint}` })
+    return blobs.length > 0 ? blobs[0] : null
+  } catch {
+    return null
+  }
+}
+
+async function setRecord(fingerprint, data) {
+  if (!BLOB_TOKEN) return
+  try {
+    const { put } = await import('@vercel/blob')
+    await put(
+      `hc-fp/${fingerprint}.json`,
+      JSON.stringify(data),
+      { access: 'public', addRandomSuffix: false, token: BLOB_TOKEN }
+    )
+  } catch (err) {
+    console.error('Blob write error:', err)
+  }
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { fingerprint, action } = req.body
+
+  if (!fingerprint) {
+    return res.status(400).json({ error: 'No fingerprint' })
+  }
+
+  // If Blob isn't configured, trust the client
+  if (!BLOB_TOKEN) {
+    return res.status(200).json({ ok: true, serverChecks: 0, trusted: false })
+  }
+
+  try {
+    const record = await getRecord(fingerprint)
+    let data = record
+      ? await fetch(record.url).then(r => r.json()).catch(() => null)
+      : null
+
+    if (!data) {
+      data = { checksUsed: 0, emailGiven: false, createdAt: new Date().toISOString() }
+    }
+
+    if (action === 'get') {
+      return res.status(200).json({ ok: true, ...data, trusted: true })
+    }
+
+    if (action === 'increment') {
+      data.checksUsed = (data.checksUsed || 0) + 1
+      data.lastSeen = new Date().toISOString()
+      await setRecord(fingerprint, data)
+      return res.status(200).json({ ok: true, ...data, trusted: true })
+    }
+
+    if (action === 'email') {
+      data.emailGiven = true
+      data.lastSeen = new Date().toISOString()
+      await setRecord(fingerprint, data)
+      return res.status(200).json({ ok: true, ...data, trusted: true })
+    }
+
+    return res.status(400).json({ error: 'Unknown action' })
+  } catch (err) {
+    console.error('Fingerprint error:', err)
+    // Fall back to trusting client
+    return res.status(200).json({ ok: true, serverChecks: 0, trusted: false })
+  }
+}

--- a/api/track.js
+++ b/api/track.js
@@ -1,0 +1,51 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { idea, fingerprint, event } = req.body
+
+  // Airtable config from environment variables
+  const baseId  = process.env.AIRTABLE_BASE_ID
+  const tableId = process.env.AIRTABLE_TABLE_ID
+  const token   = process.env.AIRTABLE_TOKEN
+
+  // If Airtable isn't configured, silently succeed — don't break the app
+  if (!baseId || !tableId || !token) {
+    return res.status(200).json({ ok: true, skipped: true })
+  }
+
+  try {
+    const response = await fetch(
+      `https://api.airtable.com/v0/${baseId}/${tableId}`,
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          fields: {
+            Idea:        idea        || '',
+            Event:       event       || 'check_run',
+            Fingerprint: fingerprint || '',
+            Date:        new Date().toISOString(),
+            Source:      req.headers['referer'] || '',
+          },
+        }),
+      }
+    )
+
+    if (!response.ok) {
+      const err = await response.json()
+      console.error('Airtable error:', err)
+      // Still return 200 — don't let tracking break the main flow
+      return res.status(200).json({ ok: false, error: err })
+    }
+
+    return res.status(200).json({ ok: true })
+  } catch (err) {
+    console.error('Track error:', err)
+    return res.status(200).json({ ok: false, error: err.message })
+  }
+}

--- a/src/HeatCheck.jsx
+++ b/src/HeatCheck.jsx
@@ -205,6 +205,12 @@ VERDICT:
       if (!text) throw new Error('Empty response')
       setReport(parseReport(text))
       paywall.incrementChecks()
+      // Fire-and-forget tracking — never blocks the user
+      fetch('/api/track', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ idea, fingerprint: paywall.fingerprint, event: 'check_run' }),
+      }).catch(() => {})
     } catch {
       setError('Something went wrong. Please try again.')
     } finally {


### PR DESCRIPTION
Implements the requested new features:

- `api/track.js`: serverless function writing check events to Airtable
- `api/check-fingerprint.js`: serverless function for server-side fingerprint usage tracking via @vercel/blob
- `src/HeatCheck.jsx`: fire-and-forget POST to /api/track after each successful check

Closes #1

Generated with [Claude Code](https://claude.ai/code)