### PR TITLE
Fix duplicate buttons on main page

### DIFF
--- a/src/HeatCheck.jsx
+++ b/src/HeatCheck.jsx
@@ -364,7 +364,7 @@ VERDICT:
                   className="submit-btn"
                   disabled={!email.trim()}
                 >
-                  Claim Free Check →
+                  Heat Check! 🔥
                 </button>
               </div>
             </form>
@@ -374,13 +374,15 @@ VERDICT:
             <span style={{ fontFamily: "'Space Mono', monospace", fontSize: '11px', color: '#2a2a2a' }}>
               {idea.length > 0 && `${idea.length} chars`}
             </span>
-            <button
-              className="submit-btn"
-              onClick={paywall.canCheck ? handleSubmit : () => paywall.setShowPaywall(true)}
-              disabled={paywall.canCheck && (loading || !idea.trim())}
-            >
-              {loading ? 'Running...' : paywall.canCheck ? 'Get Heat Check Report 🔥' : 'Get More Checks →'}
-            </button>
+            {paywall.canCheck && (
+              <button
+                className="submit-btn"
+                onClick={handleSubmit}
+                disabled={loading || !idea.trim()}
+              >
+                {loading ? 'Running...' : 'Get Heat Check Report 🔥'}
+              </button>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
Fixes #13

- Change 'Claim Free Check →' button text to 'Heat Check! 🔥'
- Remove 'Get More Checks →' button from input section (only appears in report section now when paywall limit is reached)

Generated with [Claude Code](https://claude.ai/code)