### PR TITLE
feat: capture email to Airtable on inline email submission

### DIFF
--- a/api/track.js
+++ b/api/track.js
@@ -3,7 +3,7 @@ export default async function handler(req, res) {
     return res.status(405).json({ error: 'Method not allowed' })
   }
 
-  const { idea, fingerprint, event } = req.body
+  const { idea, email, fingerprint, event } = req.body
 
   // Airtable config from environment variables
   const baseId  = process.env.AIRTABLE_BASE_ID
@@ -27,6 +27,7 @@ export default async function handler(req, res) {
         body: JSON.stringify({
           fields: {
             Idea:        idea        || '',
+            Email:       email       || '',
             Event:       event       || 'check_run',
             Fingerprint: fingerprint || '',
             Date:        new Date().toISOString(),

--- a/src/HeatCheck.jsx
+++ b/src/HeatCheck.jsx
@@ -128,6 +128,12 @@ export default function HeatCheck() {
     e.preventDefault()
     if (!email.trim()) return
     paywall.grantEmailBonus()
+    // Fire-and-forget email capture tracking — never blocks the user
+    fetch('/api/track', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, fingerprint: paywall.fingerprint, event: 'email_capture' }),
+    }).catch(() => {})
     setEmail('')
   }
 


### PR DESCRIPTION
Closes #15

## Changes

- Fire POST to `/api/track` with `email`, `fingerprint`, and `event='email_capture'` after `grantEmailBonus()` in `handleEmailSubmit` (same fire-and-forget pattern)
- Add `Email` field to Airtable record in `api/track.js`

Generated with [Claude Code](https://claude.ai/code)