### PR TITLE
fix: landing page generation flow, error logging, blob fallback, and email

### DIFF
--- a/api/generate-landing.js
+++ b/api/generate-landing.js
@@ -1,20 +1,30 @@
 export default async function handler(req, res) {
+  console.log('generate-landing: handler called', { method: req.method })
+
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' })
   }
 
   const { idea, report, email } = req.body
+  console.log('generate-landing: received data', {
+    idea: idea ? idea.slice(0, 80) + '...' : null,
+    hasReport: !!report,
+    email: email || '(none)',
+  })
+
   if (!idea || !report) {
+    console.error('generate-landing: missing required fields', { hasIdea: !!idea, hasReport: !!report })
     return res.status(400).json({ error: 'Missing required fields' })
   }
 
   const apiKey = process.env.VITE_ANTHROPIC_API_KEY
   if (!apiKey) {
+    console.error('generate-landing: VITE_ANTHROPIC_API_KEY not set')
     return res.status(500).json({ error: 'API key not configured' })
   }
 
-  // Debug: log whether Blob token is present (visible in Vercel function logs)
-  console.log('BLOB_READ_WRITE_TOKEN present:', !!process.env.BLOB_READ_WRITE_TOKEN)
+  console.log('blob token exists:', !!process.env.BLOB_READ_WRITE_TOKEN)
+  console.log('resend key exists:', !!process.env.RESEND_API_KEY)
 
   const scoresText = report.parsedScores
     ? Object.entries(report.parsedScores).map(([k, v]) => `${k}: ${v}/100`).join(', ')
@@ -63,26 +73,31 @@ Return ONLY the complete HTML file starting with <!DOCTYPE html> and ending with
       }),
     })
 
+    console.log('generate-landing: Anthropic response status:', anthropicResponse.status)
     const data = await anthropicResponse.json()
 
     if (!anthropicResponse.ok) {
+      console.error('generate-landing: Anthropic error:', data.error)
       return res.status(anthropicResponse.status).json({ error: data.error?.message || 'Anthropic error' })
     }
 
     html = data.content?.map(c => c.text || '').join('\n') || ''
 
     if (!html) {
+      console.error('generate-landing: Empty response from Anthropic')
       return res.status(500).json({ error: 'Empty response from AI' })
     }
 
     // Strip markdown code fences if Claude wrapped the HTML
     html = html.replace(/^```html\n?/, '').replace(/\n?```$/, '').trim()
+    console.log('generate-landing: HTML generated, length:', html.length)
 
   } catch (err) {
+    console.error('generate-landing: Anthropic fetch error:', err.message, err)
     return res.status(500).json({ error: 'Failed to generate landing page: ' + err.message })
   }
 
-  // Save to Vercel Blob — required for a real hosted URL
+  // Save to Vercel Blob — preferred for a real hosted URL
   let url = null
 
   try {
@@ -93,21 +108,52 @@ Return ONLY the complete HTML file starting with <!DOCTYPE html> and ending with
       contentType: 'text/html',
     })
     url = blob.url
-    console.log('Blob upload succeeded:', url)
+    console.log('generate-landing: Blob upload succeeded:', url)
   } catch (blobErr) {
-    console.error('Blob upload failed:', blobErr.message || blobErr)
-    // Never fall back to a data URL — return a proper error so the user can be helped
-    return res.status(500).json({
-      error: 'Landing page storage failed. Please email us and we will generate your page manually.',
-      detail: blobErr.message,
-    })
+    console.error('generate-landing: Blob upload failed:', blobErr.message || blobErr)
+    // Fall back to returning HTML inline so the user still gets their page
+    url = null
   }
 
   // Send email via Resend if configured and email provided
   const resendKey = process.env.RESEND_API_KEY
   if (resendKey && email) {
     try {
-      await fetch('https://api.resend.com/emails', {
+      const emailHtml = url
+        ? `
+          <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; background: #0a0a0a; color: #ffffff; padding: 40px;">
+            <h1 style="color: #ff6b35; font-size: 32px; margin-bottom: 16px;">Your Landing Page Is Ready! 🚀</h1>
+            <p style="color: #aaa; font-size: 16px; line-height: 1.6; margin-bottom: 24px;">
+              Congratulations on taking your first step to becoming an entrepreneur. Your custom landing page has been generated based on your startup idea.
+            </p>
+            <p style="margin-bottom: 32px;">
+              <a href="${url}" style="display: inline-block; background: #ff6b35; color: #0a0a0a; padding: 14px 32px; text-decoration: none; font-weight: bold; font-size: 14px; letter-spacing: 0.1em; text-transform: uppercase;">
+                View Your Landing Page →
+              </a>
+            </p>
+            <p style="color: #aaa; font-size: 14px; margin-bottom: 8px;">Or copy this URL:</p>
+            <p style="color: #ff6b35; font-size: 14px; word-break: break-all; margin-bottom: 32px;">${url}</p>
+            <p style="color: #555; font-size: 12px; margin-top: 32px;">
+              Powered by Heat Check — <a href="https://heat-check-alpha.vercel.app" style="color: #ff6b35;">heat-check-alpha.vercel.app</a>
+            </p>
+          </div>
+        `
+        : `
+          <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; background: #0a0a0a; color: #ffffff; padding: 40px;">
+            <h1 style="color: #ff6b35; font-size: 32px; margin-bottom: 16px;">Your Landing Page Is Ready! 🚀</h1>
+            <p style="color: #aaa; font-size: 16px; line-height: 1.6; margin-bottom: 24px;">
+              Congratulations on taking your first step to becoming an entrepreneur. Your landing page was generated but we had trouble hosting it automatically.
+            </p>
+            <p style="color: #aaa; font-size: 16px; line-height: 1.6;">
+              Please check the app — your page HTML is available for download. If you have any issues, reply to this email and we'll sort it out within 24 hours.
+            </p>
+            <p style="color: #555; font-size: 12px; margin-top: 32px;">
+              Powered by Heat Check — <a href="https://heat-check-alpha.vercel.app" style="color: #ff6b35;">heat-check-alpha.vercel.app</a>
+            </p>
+          </div>
+        `
+
+      const emailRes = await fetch('https://api.resend.com/emails', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -116,28 +162,23 @@ Return ONLY the complete HTML file starting with <!DOCTYPE html> and ending with
         body: JSON.stringify({
           from: 'Heat Check <onboarding@resend.dev>',
           to: [email],
-          subject: 'Your landing page is live 🚀',
-          html: `
-            <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; background: #0a0a0a; color: #ffffff; padding: 40px;">
-              <h1 style="color: #ff6b35; font-size: 32px; margin-bottom: 16px;">Your Landing Page Is Live! 🚀</h1>
-              <p style="color: #aaa; font-size: 16px; line-height: 1.6; margin-bottom: 24px;">
-                Congratulations on taking your first step to becoming an entrepreneur. Your custom landing page has been generated based on your startup idea.
-              </p>
-              <a href="${url}" style="display: inline-block; background: #ff6b35; color: #0a0a0a; padding: 14px 32px; text-decoration: none; font-weight: bold; font-size: 14px; letter-spacing: 0.1em; text-transform: uppercase;">
-                View Your Landing Page →
-              </a>
-              <p style="color: #555; font-size: 12px; margin-top: 32px;">
-                Powered by Heat Check — <a href="https://heat-check-alpha.vercel.app" style="color: #ff6b35;">heat-check-alpha.vercel.app</a>
-              </p>
-            </div>
-          `,
+          subject: 'Your landing page is ready 🚀',
+          html: emailHtml,
         }),
       })
+
+      const emailData = await emailRes.json()
+      console.log('generate-landing: Resend response status:', emailRes.status, 'body:', JSON.stringify(emailData))
+
+      if (!emailRes.ok) {
+        console.error('generate-landing: Resend failed:', emailData)
+      }
     } catch (emailErr) {
-      console.error('Resend error:', emailErr)
-      // Don't fail — email is a bonus, not required
+      console.error('generate-landing: Resend error:', emailErr)
+      // Don't fail the request — URL/HTML is still returned below
     }
   }
 
-  return res.status(200).json({ url })
+  // Return url if blob storage succeeded, otherwise return html inline
+  return res.status(200).json({ url, html: url ? null : html })
 }

--- a/src/HeatCheck.jsx
+++ b/src/HeatCheck.jsx
@@ -108,6 +108,8 @@ export default function HeatCheck() {
   const [thankYouType, setThankYouType] = useState(null)
   const [buildingLanding, setBuildingLanding] = useState(false)
   const [landingUrl, setLandingUrl] = useState(null)
+  const [landingHtml, setLandingHtml] = useState(null)
+  const [landingError, setLandingError] = useState(null)
   const paywall = usePaywall()
 
   async function generateLandingPage(pendingIdea, pendingReport, emailAddr) {
@@ -117,7 +119,8 @@ export default function HeatCheck() {
       body: JSON.stringify({ idea: pendingIdea, report: pendingReport, email: emailAddr || '' })
     })
     const data = await res.json()
-    return data.url
+    if (!res.ok) throw new Error(data.error || 'Generation failed')
+    return { url: data.url || null, html: data.html || null }
   }
 
   useEffect(() => {
@@ -136,20 +139,31 @@ export default function HeatCheck() {
           setBuildingLanding(true)
           window.history.replaceState({}, '', window.location.pathname)
           generateLandingPage(pendingIdea, pendingReport, pendingEmail)
-            .then(url => {
+            .then(({ url, html }) => {
               setBuildingLanding(false)
-              setLandingUrl(url || '')
+              if (url) {
+                setLandingUrl(url)
+              } else if (html) {
+                setLandingHtml(html)
+              } else {
+                setLandingError("Something went wrong generating your page. Email heatcheck@heat-check-alpha.vercel.app with your idea and we'll build it manually within 24 hours.")
+              }
               localStorage.removeItem('hc_pending_idea')
               localStorage.removeItem('hc_pending_report')
               localStorage.removeItem('hc_pending_email')
             })
-            .catch(() => {
+            .catch(err => {
+              console.error('Landing page generation failed:', err)
               setBuildingLanding(false)
+              setLandingError("Something went wrong generating your page. Email heatcheck@heat-check-alpha.vercel.app with your idea and we'll build it manually within 24 hours.")
               localStorage.removeItem('hc_pending_idea')
               localStorage.removeItem('hc_pending_report')
               localStorage.removeItem('hc_pending_email')
             })
-        } catch {}
+        } catch (err) {
+          console.error('Landing page init error:', err)
+          window.history.replaceState({}, '', window.location.pathname)
+        }
       } else {
         window.history.replaceState({}, '', window.location.pathname)
       }
@@ -166,11 +180,17 @@ export default function HeatCheck() {
       setBuildingLanding(true)
       window.history.replaceState({}, '', window.location.pathname)
       generateLandingPage(testIdea, testReport, testEmail)
-        .then(url => {
+        .then(({ url, html }) => {
           setBuildingLanding(false)
-          setLandingUrl(url || '')
+          if (url) setLandingUrl(url)
+          else if (html) setLandingHtml(html)
+          else setLandingError("Something went wrong generating your page. Email heatcheck@heat-check-alpha.vercel.app with your idea and we'll build it manually within 24 hours.")
         })
-        .catch(() => setBuildingLanding(false))
+        .catch(err => {
+          console.error('Landing page generation failed (test):', err)
+          setBuildingLanding(false)
+          setLandingError("Something went wrong generating your page. Email heatcheck@heat-check-alpha.vercel.app with your idea and we'll build it manually within 24 hours.")
+        })
     }
   }, [])
 
@@ -188,11 +208,17 @@ export default function HeatCheck() {
       const testIdea = idea.trim() || TEST_IDEA
       setBuildingLanding(true)
       generateLandingPage(testIdea, report, email || '')
-        .then(url => {
+        .then(({ url, html }) => {
           setBuildingLanding(false)
-          setLandingUrl(url || '')
+          if (url) setLandingUrl(url)
+          else if (html) setLandingHtml(html)
+          else setLandingError("Something went wrong generating your page. Email heatcheck@heat-check-alpha.vercel.app with your idea and we'll build it manually within 24 hours.")
         })
-        .catch(() => setBuildingLanding(false))
+        .catch(err => {
+          console.error('Landing page generation failed (keyboard shortcut):', err)
+          setBuildingLanding(false)
+          setLandingError("Something went wrong generating your page. Email heatcheck@heat-check-alpha.vercel.app with your idea and we'll build it manually within 24 hours.")
+        })
     }
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
@@ -289,7 +315,22 @@ VERDICT:
     )
   }
 
-  if (landingUrl !== null && landingUrl !== undefined) {
+  if (landingError) {
+    return (
+      <div style={{ minHeight: '100vh', background: '#0a0a0a', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '20px' }}>
+        <div style={{ width: '100%', maxWidth: '600px', textAlign: 'center' }}>
+          <div style={{ fontSize: '48px', marginBottom: '24px' }}>⚠️</div>
+          <div style={{ fontFamily: "'Space Mono', monospace", fontSize: '13px', color: '#f87171', letterSpacing: '0.1em', lineHeight: '1.8', marginBottom: '32px' }}>{landingError}</div>
+          <button
+            style={{ background: 'transparent', color: '#ff6b35', border: '1px solid #ff6b3533', padding: '13px 32px', fontFamily: "'Space Mono', monospace", fontWeight: '700', fontSize: '12px', letterSpacing: '0.1em', textTransform: 'uppercase', cursor: 'pointer' }}
+            onClick={() => { setLandingError(null); setReport(null); setIdea('') }}
+          >← Back to Heat Check</button>
+        </div>
+      </div>
+    )
+  }
+
+  if (landingUrl !== null || landingHtml !== null) {
     return (
       <div style={{ minHeight: '100vh', background: '#0a0a0a', display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '0 20px 80px' }}>
         <style>{`
@@ -323,11 +364,44 @@ VERDICT:
               <div style={{ fontSize: '11px', fontFamily: "'Space Mono', monospace", color: '#444', marginTop: '8px' }}>Click to copy</div>
             </div>
           )}
+          {!landingUrl && landingHtml && (
+            <div style={{ marginBottom: '32px', padding: '20px', background: '#0d0d0d', border: '1px solid #ff6b3530' }}>
+              <div style={{ fontSize: '10px', fontFamily: "'Space Mono', monospace", color: '#ff6b35', letterSpacing: '0.18em', textTransform: 'uppercase', marginBottom: '10px' }}>Your landing page</div>
+              <div style={{ fontFamily: "'Inter', sans-serif", fontWeight: '300', color: '#aaa', fontSize: '14px', lineHeight: '1.7', marginBottom: '16px' }}>
+                We couldn't host your page automatically, but your HTML is ready. Click below to preview or download it.
+              </div>
+            </div>
+          )}
           <div style={{ display: 'flex', gap: '14px', flexWrap: 'wrap' }}>
             {landingUrl && (
               <button className="landing-btn" onClick={() => window.open(landingUrl, '_blank')}>View My Landing Page →</button>
             )}
-            <button className="landing-outline-btn" onClick={() => { setLandingUrl(null); setReport(null); setIdea('') }}>← Back to Heat Check</button>
+            {!landingUrl && landingHtml && (
+              <button
+                className="landing-btn"
+                onClick={() => {
+                  const blob = new Blob([landingHtml], { type: 'text/html' })
+                  const blobUrl = URL.createObjectURL(blob)
+                  const a = document.createElement('a')
+                  a.href = blobUrl
+                  a.download = 'landing-page.html'
+                  a.click()
+                  URL.revokeObjectURL(blobUrl)
+                }}
+              >Download My Landing Page ↓</button>
+            )}
+            {!landingUrl && landingHtml && (
+              <button
+                className="landing-btn"
+                style={{ background: '#1a1a1a', color: '#ff6b35' }}
+                onClick={() => {
+                  const blob = new Blob([landingHtml], { type: 'text/html' })
+                  const blobUrl = URL.createObjectURL(blob)
+                  window.open(blobUrl, '_blank')
+                }}
+              >Preview in Browser →</button>
+            )}
+            <button className="landing-outline-btn" onClick={() => { setLandingUrl(null); setLandingHtml(null); setReport(null); setIdea('') }}>← Back to Heat Check</button>
           </div>
         </div>
       </div>
@@ -490,6 +564,8 @@ VERDICT:
                       localStorage.setItem('hc_pending_idea', idea)
                       localStorage.setItem('hc_pending_report', JSON.stringify(report))
                       if (email) localStorage.setItem('hc_pending_email', email)
+                      console.log('hc_pending_idea:', localStorage.getItem('hc_pending_idea'))
+                      console.log('hc_pending_report:', localStorage.getItem('hc_pending_report'))
                       const successUrl = 'https://heat-check-alpha.vercel.app?landing=paid'
                       window.location.href = `${STRIPE_LANDING}?success_url=${encodeURIComponent(successUrl)}`
                     }}


### PR DESCRIPTION
Fixes #33

Fixed the broken landing page generation flow:
- Success screen now only shows after generation completes
- Loading screen shown while awaiting API
- Error screen shown on failure with actionable message
- Blob fallback returns inline HTML with download/preview buttons
- Full error logging throughout generate-landing.js
- Email subject fixed, Resend response logged
- localStorage values logged before Stripe redirect

Generated with [Claude Code](https://claude.ai/code)