### PR TITLE
fix: add resend to package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "@stripe/stripe-js": "^3.0.0",
     "@vercel/blob": "^0.27.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "resend": "^4.0.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",


### PR DESCRIPTION
Fixes #36 - Vercel runtime crash due to missing `resend` package.

- `@vercel/blob: ^0.27.0` was already present in package.json
- Added `resend: ^4.0.0` to dependencies
- `api/generate-landing.js` was already present with full implementation

Generated with [Claude Code](https://claude.ai/code)