### PR TITLE
fix: use ANTHROPIC_API_KEY instead of VITE_ANTHROPIC_API_KEY

### DIFF
--- a/api/generate-landing.js
+++ b/api/generate-landing.js
@@ -17,9 +17,9 @@ export default async function handler(req, res) {
     return res.status(400).json({ error: 'Missing required fields' })
   }
 
-  const apiKey = process.env.VITE_ANTHROPIC_API_KEY
+  const apiKey = process.env.ANTHROPIC_API_KEY
   if (!apiKey) {
-    console.error('generate-landing: VITE_ANTHROPIC_API_KEY not set')
+    console.error('generate-landing: ANTHROPIC_API_KEY not set')
     return res.status(500).json({ error: 'API key not configured' })
   }
 


### PR DESCRIPTION
Fix generate-landing.js to use the correct environment variable name ANTHROPIC_API_KEY instead of VITE_ANTHROPIC_API_KEY. The VITE_ prefix was removed in a previous security fix.

Closes #38

Generated with [Claude Code](https://claude.ai/code)